### PR TITLE
Fix issue with incorrect text saving when backspace key used

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -205,63 +205,54 @@ registerBlockType( 'book-review-block/book-review', {
 					<RichText
 						onChange={ updateValue( 'title' ) }
 						placeholder={ __( 'Enter title…' ) }
-						tagName="span"
 						value={ title }
 						keepPlaceholderOnFocus />
 
 					<RichText
 						onChange={ updateValue( 'series' ) }
 						placeholder={ __( 'Enter series…' ) }
-						tagName="span"
 						value={ series }
 						keepPlaceholderOnFocus />
 
 					<RichText
 						onChange={ updateValue( 'author' ) }
 						placeholder={ __( 'Enter author…' ) }
-						tagName="span"
 						value={ author }
 						keepPlaceholderOnFocus />
 
 					<RichText
 						onChange={ updateValue( 'genre' ) }
 						placeholder={ __( 'Enter genre…' ) }
-						tagName="span"
 						value={ genre }
 						keepPlaceholderOnFocus />
 
 					<RichText
 						onChange={ updateValue( 'publisher' ) }
 						placeholder={ __( 'Enter publisher…' ) }
-						tagName="span"
 						value={ publisher }
 						keepPlaceholderOnFocus />
 
 					<RichText
 						onChange={ updateValue( 'releaseDate' ) }
 						placeholder={ __( 'Enter release date…' ) }
-						tagName="span"
 						value={ releaseDate }
 						keepPlaceholderOnFocus />
 
 					<RichText
 						onChange={ updateValue( 'format' ) }
 						placeholder={ __( 'Enter format…' ) }
-						tagName="span"
 						value={ format }
 						keepPlaceholderOnFocus />
 
 					<RichText
 						onChange={ updateValue( 'pages' ) }
 						placeholder={ __( 'Enter pages…' ) }
-						tagName="span"
 						value={ pages }
 						keepPlaceholderOnFocus />
 
 					<RichText
 						onChange={ updateValue( 'source' ) }
 						placeholder={ __( 'Enter source…' ) }
-						tagName="span"
 						value={ source }
 						keepPlaceholderOnFocus />
 


### PR DESCRIPTION
This PR addresses an issue with the text being saved incorrectly when the backspace key was used.
[Related Gutenberg issue](https://github.com/WordPress/gutenberg/issues/8773).

## Testing
1. Create a new post and add the Book Review block.
2. Enter _A_, then remove the _A_ by hitting the Backspace key, and then enter _B_.
3. Click _Save Draft_ and then preview the post. Refresh the editor.
4. Ensure that both the preview and the editor to show _B_.