### PR TITLE
Fix "creation of dynamic property" deprecation notice

### DIFF
--- a/book-review-block.php
+++ b/book-review-block.php
@@ -48,6 +48,15 @@ class Book_Review_Block {
 	private $version;
 
 	/**
+	 * Controller to communicate with the REST API.
+	 *
+	 * @since    2.2.1
+	 * @access   private
+	 * @var      string    $version    The current version of this plugin.
+	 */
+	private $controller;
+
+	/**
 	 * Registers the plugin.
 	 *
 	 * @since     1.0.0


### PR DESCRIPTION
Fixes the following message on PHP 8.2+:

> PHP Deprecated:  Creation of dynamic property Book_Review_Block::$controller is deprecated in /Users/donnapep/Local Sites/book-review/app/public/wp-content/plugins/book-review-block/book-review-block.php on line 74