### PR TITLE
Bump plugin version and "Tested up to" version

### DIFF
--- a/book-review-block.php
+++ b/book-review-block.php
@@ -5,7 +5,7 @@
  * Description: A Gutenberg block to add book details and a star rating to a book review post.
  * Author: Donna Peplinskie
  * Author URI: https://donnapeplinskie.com
- * Version: 2.2.1
+ * Version: 2.3.0
  * Text Domain: book-review-block
  * License: GPL2+
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
@@ -76,7 +76,7 @@ class Book_Review_Block {
 	 * @access   private
 	 */
 	private function __construct() {
-		$this->version = '2.2.1';
+		$this->version = '2.3.0';
 		$this->slug    = 'book-review-block';
 
 		require_once plugin_dir_path( __FILE__ ) . 'includes/book-review-block-settings-controller.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "book-review-block",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "book-review-block",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "dependencies": {
         "@wordpress/api-fetch": "7.37.0",
         "@wordpress/block-editor": "15.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "book-review-block",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "main": "index.js",
   "engines": {
     "node": ">=14.0.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: donnapep
 Tags: book, book blog, book review, rating, review
 Author URI: https://donnapeplinskie.com
 Requires at least: 6.2
-Tested up to: 6.6
-Stable tag: 2.2.1
+Tested up to: 6.9
+Stable tag: 2.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Bumping plugin version to 2.3.0 and "Tested up to" version to WordPress 6.9.